### PR TITLE
fix(README): download_glue example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install -r requirements.txt
 
 Download the glue tasks using e.g. :
 ```
-python download_glue.py --task_names mnli,qqp --datadir data/
+python download_glue.py --task_names mnli,qqp --data_dir data/
 ```
 
 Check `scripts/` folder for finetuning examples with gpt2, roberta-base, and llama-7b.


### PR DESCRIPTION
Hey team!

Currently looking into some lora and loraplus papers and yours looks great! Just noticed this typo when working to reproduce the results.

```shell
python download_glue.py --task_names mnli,qqp --datadir data/
> ERROR: Could not consume arg: --datadir
```

While using the following will run without error:
```shell
python download_glue.py --task_names mnli,qqp --data_dir data/
```